### PR TITLE
Improve BACH classification notebook

### DIFF
--- a/BACH_classification.ipynb
+++ b/BACH_classification.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2a145b14",
+   "metadata": {},
+   "source": [
+    "# Step 1: Data Loading"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a49da037",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "import os\n",
+    "import numpy as np\n",
+    "from sklearn.model_selection import StratifiedKFold\n",
+    "from sklearn.metrics import roc_auc_score, precision_recall_curve, auc, confusion_matrix, f1_score\n",
+    "import tensorflow as tf\n",
+    "from tensorflow.keras import layers, Model\n",
+    "from tensorflow.keras.applications import Xception\n",
+    "from tensorflow.keras.preprocessing import image\n",
+    "from tensorflow.keras.utils import to_categorical\n",
+    "import matplotlib.pyplot as plt\n",
+    "from staintools import StainNormalizer\n",
+    "\n",
+    "# Path to dataset directory\n",
+    "dataset_root = 'path_to_bach_dataset'\n",
+    "img_size = (512, 682)\n",
+    "\n",
+    "def load_image_paths(root):\n",
+    "    classes = sorted(os.listdir(root))\n",
+    "    filepaths = []\n",
+    "    labels = []\n",
+    "    for idx, cls in enumerate(classes):\n",
+    "        cls_dir = os.path.join(root, cls)\n",
+    "        for fname in os.listdir(cls_dir):\n",
+    "            if fname.lower().endswith(('png','jpg','jpeg','tif')):\n",
+    "                filepaths.append(os.path.join(cls_dir, fname))\n",
+    "                labels.append(idx)\n",
+    "    return np.array(filepaths), np.array(labels), classes\n",
+    "\n",
+    "filepaths, labels, class_names = load_image_paths(dataset_root)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f7c17f0",
+   "metadata": {},
+   "source": [
+    "# Step 2: Preprocessing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3962ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "def macenko_normalize(img_path, normalizer=None):\n",
+    "    img = image.load_img(img_path)\n",
+    "    img = image.img_to_array(img)\n",
+    "    if normalizer is not None:\n",
+    "        img = normalizer.transform(img)\n",
+    "    img = tf.image.resize(img, img_size)\n",
+    "    return img\n",
+    "\n",
+    "reference_image_path = 'path_to_reference_image'\n",
+    "reference_img = image.load_img(reference_image_path)\n",
+    "reference_img = image.img_to_array(reference_img)\n",
+    "normalizer = StainNormalizer(method='macenko')\n",
+    "normalizer.fit(reference_img.astype(np.uint8))\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "515955c4",
+   "metadata": {},
+   "source": [
+    "# Step 3: Model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6196e21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "img_in = layers.Input(shape=(img_size[0], img_size[1], 3))\n",
+    "base = Xception(weights='imagenet', include_top=False, input_tensor=img_in)\n",
+    "add_layers = [l.name for l in base.layers if l.name.startswith('add_')]\n",
+    "layer_names = add_layers[-6:]\n",
+    "\n",
+    "gap_features = [layers.GlobalAveragePooling2D()(base.get_layer(name).output) for name in layer_names]\n",
+    "concat = layers.Concatenate()(gap_features)\n",
+    "\n",
+    "dense1 = layers.Dense(512, activation='relu', kernel_regularizer=tf.keras.regularizers.l2(0.01))(concat)\n",
+    "drop1 = layers.Dropout(0.1)(dense1)\n",
+    "dense2 = layers.Dense(512, activation='relu', kernel_regularizer=tf.keras.regularizers.l2(0.01))(drop1)\n",
+    "drop2 = layers.Dropout(0.1)(dense2)\n",
+    "output = layers.Dense(len(class_names), activation='softmax')(drop2)\n",
+    "model = Model(inputs=img_in, outputs=output)\n",
+    "model.compile(loss='categorical_crossentropy', optimizer=tf.keras.optimizers.Adam(1e-5), metrics=['accuracy'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3cf7f480",
+   "metadata": {},
+   "source": [
+    "# Step 4: Training (5-Fold Stratified Cross-Validation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55048020",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "skf = StratifiedKFold(n_splits=5, shuffle=True, random_state=42)\n",
+    "all_metrics = []\n",
+    "histories = []\n",
+    "\n",
+    "for fold, (train_idx, val_idx) in enumerate(skf.split(filepaths, labels), 1):\n",
+    "    print(f'Fold {fold}')\n",
+    "    train_paths, val_paths = filepaths[train_idx], filepaths[val_idx]\n",
+    "    y_train, y_val = labels[train_idx], labels[val_idx]\n",
+    "\n",
+    "    def preprocess(paths, labels, augment=False):\n",
+    "        imgs = []\n",
+    "        for p in paths:\n",
+    "            img = macenko_normalize(p, normalizer)\n",
+    "            if augment:\n",
+    "                img = tf.image.random_flip_left_right(img)\n",
+    "                img = tf.image.random_flip_up_down(img)\n",
+    "            imgs.append(img)\n",
+    "        imgs = tf.stack(imgs)\n",
+    "        labels_cat = to_categorical(labels, num_classes=len(class_names))\n",
+    "        return imgs, labels_cat\n",
+    "\n",
+    "    x_train, y_train_cat = preprocess(train_paths, y_train, augment=True)\n",
+    "    x_val, y_val_cat = preprocess(val_paths, y_val)\n",
+    "\n",
+    "    checkpoint = tf.keras.callbacks.ModelCheckpoint(f'best_fold{fold}.h5',\n",
+    "                                                    monitor='val_accuracy',\n",
+    "                                                    save_best_only=True)\n",
+    "    history = model.fit(x_train, y_train_cat, epochs=3,\n",
+    "                        validation_data=(x_val, y_val_cat),\n",
+    "                        callbacks=[checkpoint])\n",
+    "    histories.append(history.history)\n",
+    "\n",
+    "    preds = model.predict(x_val)\n",
+    "    y_true = y_val\n",
+    "    y_score = preds\n",
+    "    y_pred = preds.argmax(axis=1)\n",
+    "\n",
+    "    f1_micro = f1_score(y_true, y_pred, average='micro')\n",
+    "    f1_macro = f1_score(y_true, y_pred, average='macro')\n",
+    "    pr_precision, pr_recall, _ = precision_recall_curve(to_categorical(y_true, num_classes=len(class_names)).ravel(),\n",
+    "                                                       y_score.ravel())\n",
+    "    pr_auc = auc(pr_recall, pr_precision)\n",
+    "    roc_auc = roc_auc_score(to_categorical(y_true, num_classes=len(class_names)), y_score, multi_class='ovr')\n",
+    "    cm = confusion_matrix(y_true, y_pred)\n",
+    "    report = classification_report(y_true, y_pred, target_names=class_names)\n",
+    "\n",
+    "    # plot confusion matrix\n",
+    "    plt.figure()\n",
+    "    sns.heatmap(cm, annot=True, fmt='d', xticklabels=class_names, yticklabels=class_names, cmap='Blues')\n",
+    "    plt.xlabel('Predicted')\n",
+    "    plt.ylabel('True')\n",
+    "    plt.title(f'Confusion Matrix Fold {fold}')\n",
+    "    plt.show()\n",
+    "    # plot training curves\n",
+    "    plt.figure()\n",
+    "    plt.plot(history.history['accuracy'], label='train_acc')\n",
+    "    plt.plot(history.history['val_accuracy'], label='val_acc')\n",
+    "    plt.xlabel('Epoch')\n",
+    "    plt.ylabel('Accuracy')\n",
+    "    plt.legend()\n",
+    "    plt.title(f'Accuracy Fold {fold}')\n",
+    "    plt.show()\n",
+    "    plt.figure()\n",
+    "    plt.plot(history.history['loss'], label='train_loss')\n",
+    "    plt.plot(history.history['val_loss'], label='val_loss')\n",
+    "    plt.xlabel('Epoch')\n",
+    "    plt.ylabel('Loss')\n",
+    "    plt.legend()\n",
+    "    plt.title(f'Loss Fold {fold}')\n",
+    "    plt.show()\n",
+    "\n",
+    "    fold_metrics = dict(f1_micro=f1_micro, f1_macro=f1_macro,\n",
+    "                        pr_auc=pr_auc, roc_auc=roc_auc,\n",
+    "                        cm=cm, report=report)\n",
+    "    all_metrics.append(fold_metrics)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4abca8fe",
+   "metadata": {},
+   "source": [
+    "# Step 5: Evaluation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f09794d",
+   "metadata": {},
+   "source": [
+    "# Step 6: Visualization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2aeac588",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "for i, m in enumerate(all_metrics, 1):\n",
+    "    print(f'Fold {i}:')\n",
+    "    print('F1 micro:', m['f1_micro'])\n",
+    "    print('F1 macro:', m['f1_macro'])\n",
+    "    print('PR AUC:', m['pr_auc'])\n",
+    "    print('ROC AUC:', m['roc_auc'])\n",
+    "    print('Classification Report:\n",
+    "', m['report'])\n",
+    "\n",
+    "avg_f1_micro = np.mean([m['f1_micro'] for m in all_metrics])\n",
+    "avg_f1_macro = np.mean([m['f1_macro'] for m in all_metrics])\n",
+    "avg_pr_auc = np.mean([m['pr_auc'] for m in all_metrics])\n",
+    "avg_roc_auc = np.mean([m['roc_auc'] for m in all_metrics])\n",
+    "\n",
+    "print('\n",
+    "Average Metrics:')\n",
+    "print('F1 micro:', avg_f1_micro)\n",
+    "print('F1 macro:', avg_f1_macro)\n",
+    "print('PR AUC:', avg_pr_auc)\n",
+    "print('ROC AUC:', avg_roc_auc)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "696dddfd",
+   "metadata": {},
+   "source": [
+    "# Step 7: Summary"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- restructure notebook with numbered headers
- fix Macenko normalization using a reference image
- add ModelCheckpoint and plots for confusion matrices and training curves
- compute classification report and show fold metrics with averages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865835072fc8322a008c6d36d4d4287